### PR TITLE
Use a lua-resty-jwt fork instead of abandoned origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This library implements a simple way to map the claim's values from a JWT Token
 to the HTTP's Headers request.
 
 Under the hood, this library uses:
-* [lua-resty-jwt](https://github.com/SkyLothar/lua-resty-jwt)
+* [lua-resty-jwt](https://github.com/cdbattags/lua-resty-jwt)
 
 [Back to TOC](#table-of-contents)
 
@@ -111,7 +111,7 @@ Then, map claim values with associated header.
 }
 ```
 
-Validators documentation is available directly on the [SkyLothar repository](https://github.com/SkyLothar/lua-resty-jwt#jwt-validators).
+Validators documentation is available directly on the [cdbattags repository](https://github.com/cdbattags/lua-resty-jwt#jwt-validators).
 
 **`config` format**
 

--- a/dist.ini
+++ b/dist.ini
@@ -7,4 +7,4 @@ lib_dir=lib
 doc_dir=lib
 repo_link=https://github.com/dailymotion/lua-nginx-guard-jwt
 main_module=lib/guardjwt.lua
-requires = luajit >= 2.1.0, ngx_http_lua >= 0.10.6, SkyLothar/lua-resty-jwt >= 0.1.9
+requires = luajit >= 2.1.0, ngx_http_lua >= 0.10.6, cdbattags/lua-resty-jwt >= 0.2.0

--- a/example/develop/Dockerfile
+++ b/example/develop/Dockerfile
@@ -13,7 +13,7 @@ RUN echo 'export PATH="/usr/local/openresty/bin:$PATH"' >> /root/.bashrc
 
 ENV PATH "/usr/local/openresty/bin:$PATH"
 
-RUN opm get SkyLothar/lua-resty-jwt=0.1.9
+RUN opm get cdbattags/lua-resty-jwt=0.2.0
 
 COPY ./lib /usr/local/openresty/site/lualib
 COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf


### PR DESCRIPTION
Due to situation with abandoned https://github.com/SkyLothar/lua-resty-jwt/issues/85 and because of the need to use OpenSSL 1.1.x it's neccessary to use up-to-date version of the lua-resty-jwt lib.

So, dependencies, examples and documentation have been updated.
