### PR TITLE
Use local functions instead of global

### DIFF
--- a/lib/guardjwt.lua
+++ b/lib/guardjwt.lua
@@ -7,7 +7,7 @@ local GuardJWT = {}
 _M.GuardJWT = GuardJWT
 
 
-function _tablelength(T)
+local function _tablelength(T)
   local count = 0
   for _ in pairs(T) do count = count + 1 end
   return count
@@ -18,7 +18,7 @@ end
 -- avoid header's injections (private method)
 --@param nginx NGINX object
 --@param claim_spec Mapping between claim's values and headers
-function _purge_headers(nginx, claim_spec)
+local function _purge_headers(nginx, claim_spec)
   for _, claim_conf in pairs(claim_spec) do
     if claim_conf.header ~= nil then
       nginx.req.clear_header(string.lower(claim_conf.header))
@@ -33,7 +33,7 @@ end
 --@param secret Secret key to decrypt JWT Token
 --@param authorization Value from header "authorization"
 --@return Claim values (Available in the token's "payload" key)
-function _guess_claim(nginx, claim_spec, secret, authorization)
+local function _guess_claim(nginx, claim_spec, secret, authorization)
   if authorization == nil then
     nginx.log(nginx.NOTICE, "[JWTGuard] No authorization header")
     return nil


### PR DESCRIPTION
During the probation of this lib with nginx I can see some errors in logs, like these:

```
2019/10/14 15:52:14 [warn] 8#8: *1 [lua] _G write guard:12: __newindex(): writing a global lua variable ('_guess_claim') which may lead to race conditions between concurrent requests, so prefer the use of 'local' variables

...
2019/10/14 15:52:14 [warn] 8#8: *1 [lua] _G write guard:12: __newindex(): writing a global lua variable ('_tablelength') which may lead to race conditions between concurrent requests, so prefer the use of 'local' variables

...
2019/10/14 15:52:14 [warn] 8#8: *1 [lua] _G write guard:12: __newindex(): writing a global lua variable ('_purge_headers') which may lead to race conditions between concurrent requests, so prefer the use of 'local' variables

```

So, I think it's pretty good to change these functions declarations to make them local. I checked such version on my environment and as I can see everything works fine.